### PR TITLE
Fixed kx.iterator implement function so it also works with objects

### DIFF
--- a/src/konflux.js
+++ b/src/konflux.js
@@ -590,7 +590,7 @@
 				if (name in collection && isType('function', collection[name]))
 					return new kxIterator(collection[name].apply(collection, arguments));
 
-				list = new window[type(collection, true)]();
+				list = collection instanceof Array ? [] : {};
 
 				keys = iterator.keys();
 				for (i = 0; i < keys.length; ++i)


### PR DESCRIPTION
This fixes kx.iterator methods which use the implement function so they can be used with objects in the collection
